### PR TITLE
Update hello cage api key usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ app.all("/encrypt", async (req, res) => {
   try {
     const result = await axios.post("http://127.0.0.1:9999/encrypt", req.body, {
       headers: {
-        "api-key": process.env('EV_API_KEY'),
+        "api-key": process.env.EV_API_KEY,
       },
     });
     res.send({ ...result.data });
@@ -63,7 +63,7 @@ app.all("/decrypt", async (req, res) => {
   try {
     const result = await axios.post("http://127.0.0.1:9999/decrypt", req.body, {
       headers: {
-        "api-key": process.env('EV_API_KEY'),
+        "api-key": process.env.EV_API_KEY,
       },
     });
 

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ app.all("/encrypt", async (req, res) => {
   try {
     const result = await axios.post("http://127.0.0.1:9999/encrypt", req.body, {
       headers: {
-        "api-key": req.headers["api-key"],
+        "api-key": process.env('EV_API_KEY'),
       },
     });
     res.send({ ...result.data });
@@ -63,7 +63,7 @@ app.all("/decrypt", async (req, res) => {
   try {
     const result = await axios.post("http://127.0.0.1:9999/decrypt", req.body, {
       headers: {
-        "api-key": req.headers["api-key"],
+        "api-key": process.env('EV_API_KEY'),
       },
     });
 


### PR DESCRIPTION
Update to use locally available api key rather than the one from the request header. This means crypto ops will work for cages without api key auth