### PR TITLE
fix: bump axios to ^1.15.2 to address CVE-2026-42035, CVE-2026-42033, CVE-2026-42264, CVE-2026-42043

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.12.0",
+        "axios": "^1.15.2",
         "express": "^5.2.0"
       }
     },
@@ -44,6 +44,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -51,14 +63,15 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/body-parser": {
@@ -363,9 +376,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -525,6 +538,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -681,9 +707,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/evervault/hello-enclave#readme",
   "dependencies": {
-    "axios": "^1.12.0",
+    "axios": "^1.15.2",
     "express": "^5.2.0"
   }
 }


### PR DESCRIPTION
Linear issue: COM-1205

## Summary

Bumps `axios` from `^1.12.0` (lockfile-resolved `1.13.6`) to `^1.15.2` to remediate four HIGH-severity advisories. `1.15.2` is the minimum version that closes all four CVEs (CVE-2026-42264 dictates the floor).

| CVE | Severity | CVSS | Fixed in |
| --- | --- | --- | --- |
| CVE-2026-42035 | HIGH | 7.4 | 1.15.1 |
| CVE-2026-42033 | HIGH | 7.4 | 1.15.1 |
| CVE-2026-42264 | HIGH | 7.4 | 1.15.2 |
| CVE-2026-42043 | HIGH | 7.2 | 1.15.1 |

**SLA deadline:** 2026-06-19T09:48:31.961Z

## Vulnerability detail

- **CVE-2026-42035** — `Object.prototype.getHeaders` + FormData duck-typing in `lib/adapters/http.js` allows arbitrary header injection on `POST/PUT/PATCH`. Reachable on `/encrypt` and `/decrypt` (which forward `req.body` directly into `axios.post`) if any future dependency introduces a prototype-pollution primitive.
- **CVE-2026-42033** — PP gadgets on `parseReviver` (silent response tampering on every JSON response) and `transport` (full request hijack / credential exfiltration). All three call sites in `index.js` parse JSON responses.
- **CVE-2026-42264** — PP gadgets on `auth`, `baseURL`, `socketPath`, `beforeRedirect`, `insecureHTTPParser`. `socketPath` pollution could silently redirect requests to a Unix socket (e.g. the Docker daemon).
- **CVE-2026-42043** — Incomplete fix for GHSA-3p68-rc4w-qgx5; `127.0.0.2`–`127.255.255.254` bypass `NO_PROXY=127.0.0.1`. Not currently exploitable here (no proxy configured) but the flawed code ships in `1.13.6`.

The current codebase lacks the PP primitive needed to weaponize three of these gadgets today, but `req.body` flows directly into `axios.post`, and this template is intended to be extended by downstream users — so patching is the right action.

## Change

```diff
   "dependencies": {
-    "axios": "^1.12.0",
+    "axios": "^1.15.2",
     "express": "^5.2.0"
   }
```

Lockfile regenerated; `axios` now resolves to a version `>= 1.15.2` within the `^1.15.2` range.

## Risk

`1.13.x → 1.15.x` is patch+minor on the same major. The API surface used in `index.js` (`axios.get(url)`, `axios.post(url, body)`, `result.data`) is stable since 1.0 — no breaking changes affect the three call sites.

## References

- https://github.com/axios/axios/security/advisories
- https://github.com/axios/axios/releases